### PR TITLE
feat(onboarding): autoplay for onboarding

### DIFF
--- a/src/app/citizenScience/datasetProgress/datasetProgressIndicator.js
+++ b/src/app/citizenScience/datasetProgress/datasetProgressIndicator.js
@@ -60,7 +60,7 @@ angular.module("bawApp.components.progressIndicator", ["bawApp.citizenScience.cs
                     element: ".progress",
                     intro: "How many items have been completed out of the total amount. ",
                     order: 3
-                });
+                }, "questionResponses");
 
                 /**
                  * Watch the total items, because it will not be ready when the controller first loads
@@ -93,6 +93,7 @@ angular.module("bawApp.components.progressIndicator", ["bawApp.citizenScience.cs
                             $scope.progress.responseCount = totalResponses;
                             self.updateProgressPercent();
                             self.refreshIn = 5;
+                            onboardingService.ready("questionResponses");
 
                         });
 

--- a/src/app/citizenScience/labels/textLabels/labels.js
+++ b/src/app/citizenScience/labels/textLabels/labels.js
@@ -21,7 +21,7 @@ angular.module("bawApp.components.citizenScienceTextLabels",
                                 order: 5
                             }
 
-                        ]);
+                        ], "questions");
                     }
                 });
 

--- a/src/app/citizenScience/labels/thumbLabels/labels.js
+++ b/src/app/citizenScience/labels/thumbLabels/labels.js
@@ -176,13 +176,16 @@ angular.module("bawApp.components.citizenScienceThumbLabels",
 
                     }
 
-                ]);
+                ], "questions");
 
                 onboardingService.addCallbacks({
                     onBeforeStart: function () {
                         $scope.$broadcast("show-label-details");
                     },
                     onExit: function () {
+                        $scope.$broadcast("hide-label-details");
+                    },
+                    onComplete: function () {
                         $scope.$broadcast("hide-label-details");
                     }
                 });

--- a/src/app/citizenScience/labels/userInput/userInput.js
+++ b/src/app/citizenScience/labels/userInput/userInput.js
@@ -17,6 +17,7 @@ angular.module("bawApp.components.citizenScienceUserInput",
                 $scope.questionData = SampleLabels.data;
                 $scope.questionDefinition = SampleLabels.question;
 
+                onboardingService.waitFor("questions");
 
                 $scope.$watch(() => SampleLabels.question.fields.length, (newVal) => {
 

--- a/src/app/citizenScience/listen/listen.js
+++ b/src/app/citizenScience/listen/listen.js
@@ -54,7 +54,6 @@ class CitizenScienceListenController {
                 element: "dataset-progress .btn",
                 intro: "When you have finished applying labels, use this button to go to the next clip",
                 order: 10
-
             },
             {
                 element: ".autoplay",
@@ -62,7 +61,11 @@ class CitizenScienceListenController {
                 order: 11
             }
 
-        ]);
+        ], "spectrogram");
+
+        $scope.$on("spectrogram-loaded", function (scope) {
+            onboardingService.ready("spectrogram");
+        });
 
         $scope.questionData = {};
 
@@ -84,7 +87,6 @@ class CitizenScienceListenController {
 
             $scope.study = studies[0];
             CitizenScienceCommon.studyData.study = $scope.study;
-
             Question.questions($scope.study.id).then(x => {
                 console.log("questions loaded", x);
 
@@ -97,6 +99,8 @@ class CitizenScienceListenController {
                 //
                 // x.data.data[0].questionData = temp;
 
+                onboardingService.ready("questions");
+
                 //TODO: update to allow multiple questions
                 $scope.questionData = x.data.data[0].questionData;
 
@@ -104,9 +108,7 @@ class CitizenScienceListenController {
             });
         });
 
-
         $scope.studyTitle = {"bristlebird": "Eastern Bristlebird Search", "koala-verification": "Koala Verification"}[$scope.csProject];
-
 
         $scope.settings = {
             "bristlebird": {
@@ -120,7 +122,6 @@ class CitizenScienceListenController {
                 showProgress: true
             }
         }[$scope.csProject];
-
 
         /**
          * When the currentItem changes, change the current audio file / spectrogram to match it
@@ -144,8 +145,6 @@ class CitizenScienceListenController {
                     }
 
                     $scope.sample.item = item;
-
-
 
                 }
             });
@@ -174,7 +173,8 @@ angular
         "bawApp.citizenScience.csLabels",
         "bawApp.components.onboarding",
         "bawApp.components.background",
-        "bawApp.citizenScience.itemInfo"
+        "bawApp.citizenScience.itemInfo",
+        "bawApp.spectrogram"
     ])
     .controller(
         "CitizenScienceListenController",

--- a/src/app/citizenScience/listen/listen.tpl.html
+++ b/src/app/citizenScience/listen/listen.tpl.html
@@ -11,7 +11,7 @@
             <div class="audio-outer">
                 <div class="audio-inner">
                     <div class="spectrogram-wrapper">
-                        <img id="spectrogram" class="spectrogram" ng-src="{{media.available.image.png.url}}">
+                        <img id="spectrogram" class="spectrogram" spectrogram ng-src="{{media.available.image.png.url}}" >
                         <div position-line media="media" audio-data="audioElementModel" image-id="'spectrogram'"></div>
                     </div>
 

--- a/src/app/citizenScience/listen/spectrogram.js
+++ b/src/app/citizenScience/listen/spectrogram.js
@@ -1,0 +1,15 @@
+angular.module("bawApp.spectrogram", [])
+    .directive("spectrogram", ["$rootScope", function ($rootScope) {
+        return {
+            restrict: "A",
+            link: function ($scope, element, attributes) {
+                element.bind("load", function() {
+                    $rootScope.$broadcast("spectrogram-loaded", $scope);
+
+                });
+                element.bind("error", function(){
+                    console.log("spectrogram could not be loaded");
+                });
+            }
+        };
+    }]);

--- a/src/app/citizenScience/listen/spectrogram.js
+++ b/src/app/citizenScience/listen/spectrogram.js
@@ -3,13 +3,15 @@ angular.module("bawApp.spectrogram", [])
         return {
             restrict: "A",
             link: function ($scope, element, attributes) {
-                element.bind("load", function() {
-                    $rootScope.$broadcast("spectrogram-loaded", $scope);
 
+                element[0].addEventListener("load", event => {
+                    $rootScope.$broadcast("spectrogram-loaded", $scope);
                 });
-                element.bind("error", function(){
+
+                element[0].addEventListener("error", event => {
                     console.log("spectrogram could not be loaded");
                 });
+
             }
         };
     }]);

--- a/src/app/onboarding/_onboarding.scss
+++ b/src/app/onboarding/_onboarding.scss
@@ -2,6 +2,16 @@
   cursor: pointer;
   opacity: 0.8;
 
+  &.loading {
+    opacity: 0.2;
+    text-shadow: 0px 0px 10px #fff;
+  }
+
+  &.ready {
+    transition: opacity 2s;
+    animation: 0.3s linear 1s wobble;
+  }
+
   &:before {
     /* questionmark: f059
        information: f05a */
@@ -12,6 +22,7 @@
 
   &:hover {
     opacity: 1;
+    transition: opacity 0.2s;
   }
 
 }
@@ -20,5 +31,13 @@ h1, h2, h3 {
   .info-launch {
     float: right;
   }
+}
+
+@keyframes wobble {
+  20% { -webkit-transform: rotate(-30deg) scale(1.1); transform:rotate(-30deg) scale(1.1); }
+  40% { -webkit-transform: rotate(25deg) scale(1.2); transform:rotate(25deg) scale(1.2); }
+  60% { -webkit-transform: rotate(-20deg) scale(1.2); transform:rotate(-20deg) scale(1.2); }
+  80% { -webkit-transform: rotate(15deg) scale(1.1); transform:rotate(15deg) scale(1.1); }
+  100% { -webkit-transform: rotate(0deg) scale(1); transform:rotate(0deg) scale(1); }
 }
 

--- a/src/app/onboarding/infoButton.tpl.html
+++ b/src/app/onboarding/infoButton.tpl.html
@@ -1,4 +1,5 @@
 <span class="info-launch"
+      ng-class="status"
       title="Launch the tour"
       ng-click="launchTour()"
 </span>

--- a/src/app/onboarding/onboarding.js
+++ b/src/app/onboarding/onboarding.js
@@ -150,12 +150,12 @@ angular.module("bawApp.components.onboarding", ["bawApp.citizenScience.common", 
                  */
                 addCallbacks: function (callbacks, add = true) {
                     if (add) {
-                        Object.keys(callbacks).forEach(cb => {
+                        Object.keys(callbacks).forEach(callback => {
                             // if there is already a callback function, nest the old and new in a new function.
-                            if (add && self.callbacks.hasOwnProperty(cb)) {
-                                self.callbacks[cb].push(callbacks[cb]);
+                            if (add && self.callbacks.hasOwnProperty(callback)) {
+                                self.callbacks[callback].push(callbacks[callback]);
                             } else {
-                                self.callbacks[cb] = [callbacks[cb]];
+                                self.callbacks[callback] = [callbacks[callback]];
                             }
                         });
                     }
@@ -210,7 +210,13 @@ angular.module("bawApp.components.onboarding", ["bawApp.citizenScience.common", 
 
                 var self = this;
 
-                $scope.status = "loading";
+                const statuses = {
+                    loading: "loading",
+                    ready: "ready",
+                    open: "open"
+                };
+
+                $scope.status = statuses.loading;
 
                 $scope.launchTour = function launchTour () {
 
@@ -224,8 +230,8 @@ angular.module("bawApp.components.onboarding", ["bawApp.citizenScience.common", 
 
                         // use timeouts to ensure that digest cycles are complete before starting
                         $timeout(() => {
-                            for (let i = 0; i < onboardingService.callbacks.onBeforeStart.length; i++) {
-                                onboardingService.callbacks.onBeforeStart[i].call();
+                            for (const onBeforeStartFunction of onboardingService.callbacks.onBeforeStart) {
+                                onBeforeStartFunction.call();
                             }
                             $timeout(() => {
                                 ngIntroService.start();
@@ -249,16 +255,10 @@ angular.module("bawApp.components.onboarding", ["bawApp.citizenScience.common", 
                     return onboardingService.isReady();
                     }, function (isReady) {
                         if (isReady) {
-                            $scope.status = "ready";
+                            $scope.status = statuses.ready;
                             if (!onboardingService.hasViewedAll()) {
                                 ngIntroService.hideHints();
                                 $scope.launchTour();
-                                // $timeout.cancel(self.autoplayTimeout);
-                                // ngIntroService.hideHints();
-                                // self.autoplayTimeout = $timeout(function () {
-                                //     ngIntroService.hideHints();
-                                //     $scope.launchTour();
-                                // }, 500);
                             }
                         }
                 });
@@ -282,25 +282,23 @@ angular.module("bawApp.components.onboarding", ["bawApp.citizenScience.common", 
 
                 self.onClose = function () {
                     $timeout(function () {
-                        $scope.status = "ready";
+                        $scope.status = statuses.ready;
                     }, 1000);
                 };
 
                 self.init = function () {
 
-                    $scope.status = "open";
+                    $scope.status = statuses.open;
 
                     // set all the callbacks
-                    Object.keys(onboardingService.callbacks).forEach((cb) => {
+                    Object.keys(onboardingService.callbacks).forEach(callback => {
                         // each value is an array of functions, so we wrap them in a function and call each one.
-                        if (angular.isFunction(ngIntroService[cb])) {
-                            ngIntroService[cb](function (arg) {
-                                for (let i = 0; i < onboardingService.callbacks[cb].length; i++) {
-                                    onboardingService.callbacks[cb][i](arg);
+                        if (angular.isFunction(ngIntroService[callback])) {
+                            ngIntroService[callback](function (arg) {
+                                for (let i = 0; i < onboardingService.callbacks[callback].length; i++) {
+                                    onboardingService.callbacks[callback][i](arg);
                                 }
                             });
-                        } else {
-                            console.log("no function", cb);
                         }
 
                     });


### PR DESCRIPTION
If the user has seen all the steps of onboarding or if they have exited early,
onboarding will not autoplay. This is recorded using local storage - so it will be true
for the device, not the user.
Because the onboarding service/component may potentially be shared by different pages,
it records when the user has seen each step, and checks to see whether the user has previouslyseen (or exited before seeing) all the steps currently loaded. Another screen that involvesonboarding with different steps will still autoplay.

For onboarding to work, it needs to know when all the elements that are in the tour have finished loading. Some of those elements may not exist before xhr responses have been received. The spectrogram image may exist but not be displayed properly while it is loading. To allow for this, the onboarding service can be registered with messages that it must wait for before being considered "ready".

These ready messages are sent in the success handler of a http request. For the spectrogram, a new directive was created that broadcasts an event when the spectrogram has finished loading.

The info button - used to manually launch the tour - now draws attention to itself after the tour is ready and when it closes. If the tour autoplays and is closed, the button draws attention to itself to show how to reopen it if needed. This is done through css animation.

An change was also made to allow more than one event handler for the same event, e.g. many
onExit handlers. This allows event handlers to be registered with the service from anywhere independently. In this case, it was needed since the animation on the button is triggered on exit, and the label examples are also closed on exit.